### PR TITLE
Make gitterbot ignore messages from itself

### DIFF
--- a/lib/bot/GBot.js
+++ b/lib/bot/GBot.js
@@ -31,6 +31,9 @@ var GBot = {
         this.gitter = new Gitter(AppConfig.token);
         this.joinKnownRooms();
         this.joinBonfireRooms();
+        this.gitter.currentUser().then(function(user) {
+          that.botName = user.username
+        })
 
         // listen to other rooms for 1:1
         if (AppConfig.supportDmRooms) {
@@ -185,7 +188,7 @@ var GBot = {
         } else {
             var output = BotCommands['wiki'](input, this);
         }
-        
+
         this.listReplyOptions = [];
         return output;
     },
@@ -299,6 +302,10 @@ var GBot = {
                 return true;
             }
         }
+        if (this.botName === who) {
+          return true;
+        }
+
         return false;
     },
 


### PR DESCRIPTION
This will refactor Gitterbot to automatically ignore messages from itself. It was previously designed to ignore all bots, configured as "botlist" in "AppConfig.js":

`botlist: ["bothelp", "camperbot", "YOUR_GITHUB_ID", "demobot"]`

Since our objective is to help users get up and running with as little configuration as possible, this change automatically checks the authenticated username and adds it as a property to GBot. Then, when `isBot` is called, it checks the configured list in AppConfig, and also checks the new `botName` property.

